### PR TITLE
chore: update the shortcut on the frontpage

### DIFF
--- a/components/shortcuts/index.js
+++ b/components/shortcuts/index.js
@@ -15,12 +15,12 @@ const items = [
     url: '/cross-chain',
   },
   {
-    title: 'EVM votes',
+    title: 'EVM polls',
     description: '',
     icon: (
       <MdOutlineHowToVote size={32} />
     ),
-    url: '/evm-votes',
+    url: '/evm-polls',
   },
   {
     title: 'Heartbeats',


### PR DESCRIPTION
Change the "evm-votes" shortcut to "evm-polls" as we deprecated the evm-votes route